### PR TITLE
update Test::Simple to 1.302098

### DIFF
--- a/linode-cli.rb
+++ b/linode-cli.rb
@@ -136,8 +136,8 @@ class LinodeCli < Formula
   end
 
   resource 'Test::Simple' do
-    url 'http://www.cpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302086.tar.gz'
-    sha256 '21e4c93c52529a10ef970afcf2cdb5719bcfef5f71af09cad3675fcf021995b1'
+    url 'http://www.cpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302098.tar.gz'
+    sha256 'd6bee89eab25356389a9fafd81688e83aa7814b2635e608cdd8a2cb114617ecc'
   end
 
   resource 'CPAN::Meta::YAML' do


### PR DESCRIPTION
Currently getting
```
==> Downloading http://www.cpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302086

curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "linode-cli--Test::Simple"
Download failed: http://www.cpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302086.tar.gz
```