### PR TITLE
update test-simple to fix 404 error

### DIFF
--- a/linode-cli.rb
+++ b/linode-cli.rb
@@ -136,8 +136,8 @@ class LinodeCli < Formula
   end
 
   resource 'Test::Simple' do
-    url 'http://www.cpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302120.tar.gz'
-    sha256 'c82360092d4dacd6e3248b613fa00053072fe9cf55d022f1e0f427f51d04346c'
+    url 'http://www.cpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302133.tar.gz'
+    sha256 '02bc2b4ec299886efcc29148308c9afb64e0f2c2acdeaa2dee33c3adfe6f96e2'
   end
 
   resource 'CPAN::Meta::YAML' do


### PR DESCRIPTION
This fixes an install error since http://www.cpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302120.tar.gz does not exist anymore